### PR TITLE
Funkcja loadera przekazana do funkcji spl_autoload_register nie powinna rzucać wyjątków

### DIFF
--- a/src/nSolutions/Filmweb.php
+++ b/src/nSolutions/Filmweb.php
@@ -156,7 +156,5 @@ class Filmweb
         $class = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Filmweb' . DIRECTORY_SEPARATOR . strtr($class, ['\\' => '/']) . '.php';
         if(file_exists($class))
             include $class;
-        else
-            throw new \Exception('Could not find class: Filmweb_'.basename($class));
     }
 }


### PR DESCRIPTION
Funkcja loadera przekazana do funkcji spl_autoload_register nie powinna rzucać wyjątków, ponieważ zaburza wykonywanie innych autoloaderów (w tym composera) 